### PR TITLE
kubevirt: Fork, add qemu-guest-agent

### DIFF
--- a/kubevirt
+++ b/kubevirt
@@ -1,1 +1,0 @@
-cloud-init

--- a/kubevirt/Containerfile
+++ b/kubevirt/Containerfile
@@ -1,0 +1,6 @@
+# This includes cloud-init plus qemu-guest-agent, which kubevirt also
+# prefers to have.
+FROM registry.redhat.io/rhel9/rhel-bootc:9.4
+RUN dnf -y install cloud-init qemu-guest-agent && \
+    ln -s ../cloud-init.target /usr/lib/systemd/system/default.target.wants && \
+    dnf clean all


### PR DESCRIPTION
- Also switch to just `dnf clean all`, even though it doesn't clean all right now.


Closes: https://github.com/redhat-cop/rhel-bootc-examples/issues/3