### PR TITLE
fips: Import from https://gitlab.com/fedora/bootc/examples/-/tree/main/fips

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ As a result, this example repository focuses on two things:
 
 ### Systems configuration
 
+- [fips](fips) - Enable FIPS
 - [container-auth](container-auth) - Currently, authentication file locations
   for `bootc` and `podman` different, and there are some subtleties in the `podman`
   location; this writes a pull secret to a central location embedded in the container

--- a/fips/01-fips.toml
+++ b/fips/01-fips.toml
@@ -1,0 +1,2 @@
+# Enable FIPS
+kargs = ["fips=1"]

--- a/fips/Containerfile
+++ b/fips/Containerfile
@@ -1,0 +1,8 @@
+FROM quay.io/centos-bootc/centos-bootc:stream9
+## Enable fips=1 kernel argument: https://containers.github.io/bootc/building/kernel-arguments.html
+COPY 01-fips.toml /usr/lib/bootc/kargs.d/
+# Enable the FIPS crypto policy
+RUN update-crypto-policies --no-reload --set FIPS
+# And that's it. The other tasks are already handled:
+# - FIPS dracut module is built-in to the base image
+# - We default to a boot=UUID= karg in bootc install-to-filesystem


### PR DESCRIPTION


The functionality has shipped in 9.5 now.