### PR TITLE
sealing: Various cleanups

### DIFF
--- a/sealing/.github/workflows/build-sealed.yml
+++ b/sealing/.github/workflows/build-sealed.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           podman build \
             --secret id=secureboot_key,src=/tmp/keys/sb-db.key \
+            --secret id=secureboot_cert,src=keys/db.crt \
             -t localhost/sealed-host:latest .
 
       - name: Log in to GHCR

--- a/sealing/Containerfile
+++ b/sealing/Containerfile
@@ -5,12 +5,15 @@
 # digest; Secure Boot verifies the UKI, which in turn verifies every
 # file on the root filesystem via fs-verity.
 #
-# The db certificate (public) is read from the build context.
-# Only the db private key is a build secret.
+# Both the db private key and the db certificate are passed as build
+# secrets.  The cert is public, but using a secret mount avoids
+# SELinux label mismatches on bind-mounted host files and keeps the
+# cert out of any image layer.
 #
 # Build:
 #   podman build \
 #     --secret id=secureboot_key,src=target/keys/sb-db.key \
+#     --secret id=secureboot_cert,src=keys/db.crt \
 #     -t localhost/sealed-host:latest .
 
 # --- Stage: rootfs-builder (install packages on the bootc base) ---
@@ -34,24 +37,13 @@ RUN --mount=type=tmpfs,target=/run --mount=type=tmpfs,target=/tmp \
 type = "ext4"
 EOF
 
-# Include the bootc dracut module in the initramfs so that composefs
-# root setup happens during boot (the module's check() returns 255,
-# meaning it's never auto-included). Then rebuild the initramfs.
-RUN --mount=type=tmpfs,target=/run --mount=type=tmpfs,target=/tmp \
-    mkdir -p /etc/dracut.conf.d && \
-    echo 'add_dracutmodules+=" bootc "' > /etc/dracut.conf.d/50-bootc-composefs.conf && \
-    kver=$(ls /usr/lib/modules/) && \
-    dracut --force --kver "$kver" /usr/lib/modules/$kver/initramfs.img && \
-    echo "Rebuilt initramfs with bootc module" && \
-    lsinitrd /usr/lib/modules/$kver/initramfs.img | grep -c bootc
-
 # Sign systemd-boot with our Secure Boot key so UEFI firmware will load it.
 # This must happen BEFORE the flatten so the signed binary is in the digest.
 RUN --mount=type=tmpfs,target=/run --mount=type=tmpfs,target=/tmp \
     --mount=type=secret,id=secureboot_key \
-    --mount=type=bind,source=keys/db.crt,target=/tmp/db.crt \
+    --mount=type=secret,id=secureboot_cert \
     sbsign --key /run/secrets/secureboot_key \
-           --cert /tmp/db.crt \
+           --cert /run/secrets/secureboot_cert \
            --output /tmp/systemd-bootx64.efi.signed \
            /usr/lib/systemd/boot/efi/systemd-bootx64.efi && \
     mv /tmp/systemd-bootx64.efi.signed /usr/lib/systemd/boot/efi/systemd-bootx64.efi
@@ -70,18 +62,17 @@ FROM base AS kernel
 RUN --mount=type=tmpfs,target=/run --mount=type=tmpfs,target=/tmp \
     --mount=type=bind,from=base,target=/target \
     --mount=type=secret,id=secureboot_key \
-    --mount=type=bind,source=keys/db.crt,target=/tmp/db.crt <<EORUN
+    --mount=type=secret,id=secureboot_cert <<EORUN
 set -xeuo pipefail
 mkdir -p /out
 bootc container ukify --rootfs /target \
   --karg rw \
-  --karg enforcing=0 \
   --karg console=hvc0,115200 \
   --karg systemd.journald.forward_to_console=1 \
   -- \
   --signtool sbsign \
   --secureboot-private-key /run/secrets/secureboot_key \
-  --secureboot-certificate /tmp/db.crt \
+  --secureboot-certificate /run/secrets/secureboot_cert \
   --output /out/uki.efi
 ls -lh /out/
 EORUN

--- a/sealing/Justfile
+++ b/sealing/Justfile
@@ -33,11 +33,13 @@ build-host:
     fi
     podman build \
         --secret id=secureboot_key,src="{{keys_dir}}/sb-db.key" \
+        --secret id=secureboot_cert,src=keys/db.crt \
         -t "{{host_image}}" .
     echo "Host image built: {{host_image}}"
 
-# Boot a VM with the composefs backend and verify.
-bcvk-ssh: build-host
+# Internal: boot the VM (used by bcvk-ssh and bcvk-test).
+[private]
+bcvk-boot: build-host
     #!/bin/bash
     set -euo pipefail
 
@@ -57,7 +59,24 @@ bcvk-ssh: build-host
         timeout 120 bash -c \
             'systemctl is-active multi-user.target || journalctl -b --no-pager -o cat UNIT=multi-user.target --follow | grep -q -m1 "Reached target"'
 
-    echo "==> multi-user.target reached, running checks..."
+    echo "==> multi-user.target reached."
+
+# Boot a VM and open an interactive SSH session.
+bcvk-ssh: bcvk-boot
+    #!/bin/bash
+    set -euo pipefail
+    VM_NAME="sealed-demo"
+    bcvk libvirt ssh "${VM_NAME}"
+
+# Boot a VM, verify composefs, and tear down.
+bcvk-test: bcvk-boot
+    #!/bin/bash
+    set -euo pipefail
+
+    VM_NAME="sealed-demo"
+    trap 'echo "==> Cleaning up VM..."; bcvk libvirt rm --stop --force "${VM_NAME}"; echo "Done."' EXIT
+
+    echo "==> Running checks..."
     bcvk libvirt ssh "${VM_NAME}" -- bash -c '
         set -euo pipefail
 
@@ -79,10 +98,6 @@ bcvk-ssh: build-host
         echo ""
         echo "=== COMPOSEFS BOOT VERIFIED ==="
     '
-
-    echo "==> Cleaning up VM..."
-    bcvk libvirt rm --stop --force "${VM_NAME}"
-    echo "Done."
 
 # Clean generated artifacts and VM
 clean:

--- a/sealing/README.md
+++ b/sealing/README.md
@@ -1,13 +1,16 @@
 # Sealed composefs boot
 
 This example builds a CentOS Stream 10 bootc host that boots with the
-composefs backend. A signed Unified Kernel Image (UKI) embeds the
+[bootc composefs backend](https://bootc.dev/bootc/experimental-composefs.html). A signed Unified Kernel Image (UKI) embeds the
 composefs digest of the root filesystem. At boot:
 
 1. UEFI Secure Boot verifies the UKI signature against enrolled keys
 2. The kernel starts with `composefs=<digest>` in the command line
 3. The initramfs mounts the root as a composefs overlay with `verity=require`
 4. Every file access is verified against its fs-verity digest
+
+Note that this support is currently experimental! But we are interested
+in feedback.
 
 ## Quick start with bcvk
 
@@ -20,12 +23,6 @@ just keygen
 This generates PK, KEK, and db keypairs in `target/keys/` and copies
 `db.crt` into `keys/` for committing. PK and KEK are only used for
 firmware enrollment (bcvk handles this); db signs the boot artifacts.
-
-You also need `virt-firmware` for OVMF key enrollment:
-
-```sh
-pip install virt-firmware
-```
 
 ### 2. Build and boot
 
@@ -42,7 +39,6 @@ the root is a composefs overlay with `verity=require`.
 ```sh
 just build-host
 bcvk libvirt run --detach --ssh-wait --name sealed-demo \
-    --filesystem=ext4 \
     --secure-boot-keys target/keys \
     localhost/sealed-host:latest
 bcvk libvirt ssh sealed-demo
@@ -55,7 +51,7 @@ mount | grep ' / '
 # composefs:<digest> on / type overlay (ro,verity=require)
 
 cat /proc/cmdline
-# composefs=<digest> rw enforcing=0 ...
+# composefs=<digest> rw ...
 ```
 
 Clean up:
@@ -109,30 +105,3 @@ For CI, set one GitHub Actions secret:
 | `SECUREBOOT_DB_KEY` | Secure Boot db private key (PEM) |
 
 PR builds use ephemeral keys so no secrets are needed for CI validation.
-
-## Key learnings
-
-- The rootfs must be flattened to a single layer (`FROM scratch` +
-  `COPY --from=`) for deterministic composefs digests
-  ([composefs-rs#132](https://github.com/containers/composefs-rs/issues/132)).
-
-- `rw` must be in the kernel cmdline so the backing ext4 is mounted
-  read-write (needed for `/etc` and `/var` bind mounts from state).
-
-- The `51bootc` dracut module must be explicitly added via
-  `dracut.conf.d` and the initramfs rebuilt — its `check()` returns
-  255 so it's never auto-included.
-
-- systemd-boot must be signed with the db key before the `FROM scratch`
-  flatten so the signed binary is in the composefs digest.
-
-- SELinux must be permissive (`enforcing=0`) for composefs boot
-  ([bootc#1826](https://github.com/bootc-dev/bootc/issues/1826)).
-
-- First boot takes ~3 minutes because sshd-keygen runs late.
-
-## Current limitations
-
-- **SELinux must be permissive.** Composefs content-store objects get
-  `unlabeled_t` labels; a policy module or relabeling is needed.
-- **x86_64 only.**


### PR DESCRIPTION
- SELinux can now be enforcing with latest bootc
- Don't need the initramfs regen
- I ran into weird SELinux denials with bind mounts for the cert, switching to a secret fixed those (even though it's public data)

etc.

Assisted-by: OpenCode (Claude Opus 4)
